### PR TITLE
Add chat sidebar and interactive chat endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,26 +7,35 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>ResumeGenie</h1>
-    <form id="resume-form">
-      <label>Name<input type="text" id="name" required></label>
-      <label>Contact<input type="text" id="contact" required></label>
-      <label>Work Experience<textarea id="experience"></textarea></label>
-      <label>Skills<textarea id="skills"></textarea></label>
-      <label>Education<textarea id="education"></textarea></label>
-      <label>Template
-        <select id="template">
-          <option value="template1">Classic</option>
-          <option value="template2">Modern</option>
-          <option value="template3">Minimal</option>
-        </select>
-      </label>
-      <label>Accent Color<input type="color" id="color" value="#0d6efd"></label>
-      <button type="submit">Generate</button>
-    </form>
-    <div id="preview" class="template1"></div>
-    <button id="download" disabled>Download PDF</button>
+  <div class="app">
+    <div class="container">
+      <h1>ResumeGenie</h1>
+      <form id="resume-form">
+        <label>Name<input type="text" id="name" required></label>
+        <label>Contact<input type="text" id="contact" required></label>
+        <label>Work Experience<textarea id="experience"></textarea></label>
+        <label>Skills<textarea id="skills"></textarea></label>
+        <label>Education<textarea id="education"></textarea></label>
+        <label>Template
+          <select id="template">
+            <option value="template1">Classic</option>
+            <option value="template2">Modern</option>
+            <option value="template3">Minimal</option>
+          </select>
+        </label>
+        <label>Accent Color<input type="color" id="color" value="#0d6efd"></label>
+        <button type="submit">Generate</button>
+      </form>
+      <div id="preview" class="template1"></div>
+      <button id="download" disabled>Download PDF</button>
+    </div>
+    <aside id="chat-sidebar">
+      <div id="chat-history"></div>
+      <form id="chat-form">
+        <input type="text" id="chat-input" placeholder="Ask ResumeGenie..." autocomplete="off" />
+        <button type="submit">Send</button>
+      </form>
+    </aside>
   </div>
   <script src="script.js"></script>
 </body>

--- a/public/script.js
+++ b/public/script.js
@@ -31,3 +31,40 @@ document.getElementById('color').addEventListener('input', (e) => {
 document.getElementById('download').addEventListener('click', () => {
   window.print();
 });
+
+// Chat functionality
+const chatHistory = [];
+
+function appendMessage(role, text) {
+  const div = document.createElement('div');
+  div.className = `msg ${role}`;
+  div.textContent = text;
+  document.getElementById('chat-history').appendChild(div);
+}
+
+document.getElementById('chat-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const input = document.getElementById('chat-input');
+  const message = input.value.trim();
+  if (!message) return;
+  appendMessage('user', message);
+  chatHistory.push({ role: 'user', content: message });
+  input.value = '';
+
+  const res = await fetch('/api/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages: chatHistory })
+  });
+  const data = await res.json();
+  const reply = data.reply || '';
+  appendMessage('assistant', reply);
+  chatHistory.push({ role: 'assistant', content: reply });
+
+  if (data.color) {
+    document.documentElement.style.setProperty('--accent', data.color);
+  }
+  if (data.preview) {
+    document.getElementById('preview').textContent = data.preview;
+  }
+});

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,9 +7,15 @@ body {
   padding: 20px;
   background: #f5f5f5;
 }
+.app {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
 .container {
+  flex: 1;
   max-width: 800px;
-  margin: auto;
+  margin: 0 auto;
   background: #fff;
   padding: 20px;
   border-radius: 8px;
@@ -39,4 +45,33 @@ form input, form textarea, form select {
 .template3 {
   font-size: 14px;
   line-height: 1.2;
+}
+#chat-sidebar {
+  width: 250px;
+  border-left: 1px solid #ccc;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+}
+#chat-history {
+  flex: 1;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+#chat-history .msg {
+  margin-bottom: 8px;
+}
+#chat-history .msg.user {
+  font-weight: bold;
+}
+#chat-form {
+  display: flex;
+  gap: 6px;
+}
+#chat-input {
+  flex: 1;
+  padding: 8px;
+}
+#chat-form button {
+  padding: 8px 12px;
 }

--- a/server.js
+++ b/server.js
@@ -39,5 +39,34 @@ app.post('/api/generate', async (req, res) => {
   }
 });
 
+app.post('/api/chat', async (req, res) => {
+  const { messages } = req.body;
+  try {
+    if (!openai) {
+      const last = messages[messages.length - 1]?.content || '';
+      return res.json({ reply: `Echo: ${last}` });
+    }
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant for editing a resume web app. Respond with a JSON object containing keys reply, and optional color or preview.' },
+        ...messages
+      ]
+    });
+
+    const content = completion.choices[0].message.content;
+    let data;
+    try {
+      data = JSON.parse(content);
+    } catch {
+      data = { reply: content };
+    }
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Chat failed.' });
+  }
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`ResumeGenie server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- Add chat sidebar component with message history and input form
- Implement client-side chat logic to send context to new `/api/chat` endpoint and apply color/preview updates from responses
- Introduce `/api/chat` server endpoint using OpenAI or fallback echo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894c2a9a9788333adc30c1ddb4260d8